### PR TITLE
fix: add missing @xterm/xterm and @xterm/addon-fit dependencies

### DIFF
--- a/tiger_cowork/client/package.json
+++ b/tiger_cowork/client/package.json
@@ -15,6 +15,8 @@
     "react-syntax-highlighter": "^15.5.0",
     "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0",
     "socket.io-client": "^4.7.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- `@xterm/xterm` and `@xterm/addon-fit` are imported in `Terminal.tsx` but were missing from `client/package.json`
- This causes `vite build` to fail on fresh installs (tested on MacOS)
- Without a successful build, `client/dist` is never created, so the production server returns a 404 on `GET /`
## Reproduction
1. Fresh install (no `node_modules` cache) -> server returns a 404 on `GET /`
2. ssh into the VM -> `cd client && npm install && npx vite build`
3. Build fails: `Rollup failed to resolve import "@xterm/xterm"`
## Fix
Added the two missing dependencies to `client/package.json`. 

If this isn't useful and I am the one missing some step, please feel free to close this and explain :D

